### PR TITLE
Update permalinks-customizer.php

### DIFF
--- a/permalinks-customizer.php
+++ b/permalinks-customizer.php
@@ -348,7 +348,7 @@ function permalinks_customizer_request($query) {
 
 function permalinks_customizer_get_sample_permalink_html($html, $id, $new_title, $new_slug) {
    $permalink = get_post_meta( $id, 'permalink_customizer', true );
-   $post = &get_post($id);
+   $post = get_post($id);
   
    ob_start();
    ?>


### PR DESCRIPTION
Fix to line 351. Previous line threw warning, "PHP Strict Standards:  Only variables should be assigned by reference."
